### PR TITLE
FIX: Cast exception when Running all tests

### DIFF
--- a/ImplemenationCTestTestAdapter/CTestExecutor.cs
+++ b/ImplemenationCTestTestAdapter/CTestExecutor.cs
@@ -35,11 +35,9 @@ namespace ImplemenationCTestTestAdapter
     /// <param name="frameworkHandle"></param>
     public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
     {
-      var tcs = sources.Select(src =>
-        CTestCase.Parse(src))
-        .Cast<TestCase>()
-        .Where(it => it != null)
-        .ToList();
+      var tcs = sources.Select(src => (TestCase)CTestCase.Parse(src))
+          .Where(it => it != null)
+          .ToList();
       RunTests(tcs, runContext, frameworkHandle);
     }
 


### PR DESCRIPTION
When trying to run all tests, got
  Unable to cast object of type 'ImplemenationCTestTestAdapter.CTestCase' to type 'Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase'

Indeed, CTestCase do not inherit from TestCast (which is sealed) so we cannot
use Cast to convert from CTestCase to TestCase.
Use conversion operation inside Select instead
